### PR TITLE
Hello World example needs size method to be implemented

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -45,7 +45,7 @@ explore the contents under <mountpoint>
 
 Happy Filesystem Hacking!
 
-=== the hello world filesystem in 14 LOC
+=== the hello world filesystem in 17 LOC
 
   require 'rfusefs'
 
@@ -58,6 +58,9 @@ Happy Filesystem Hacking!
     end
     def read_file(path)
       "Hello, World!\n"
+    end
+    def size(path)
+      read_file(path).size
     end
   end
 


### PR DESCRIPTION
The existing Hello World in the README omits the size method, which is present in the code in the `samples` dir.  Without this, `cat hello.txt` returns nothing.
